### PR TITLE
renamed from allow_communications to allow_messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Each response will include a `status` object and (if successful) a `result` (`re
                   "display_name": "Phone Number",
                   "inbound_notification_url": null,
                   "outbound_notification_url": null,
-                  "allow_communications": true
+                  "allow_messages": true
               }
           }
         ],
@@ -93,7 +93,7 @@ Each response will include a `status` object and (if successful) a `result` (`re
               "display_name": "Phone Number",
               "inbound_notification_url": null,
               "outbound_notification_url": null,
-              "allow_communications": true
+              "allow_messages": true
           }
         ],
         "service_address": {

--- a/channel_types/GET_id.md
+++ b/channel_types/GET_id.md
@@ -26,7 +26,7 @@ None
         "display_name": "Phone Number",
         "inbound_notification_url": null,
         "outbound_notification_url": null,
-        "allow_communications": true,
+        "allow_messages": true,
         "priority": 0,
         "is_global": true
     }    

--- a/channel_types/GET_list.md
+++ b/channel_types/GET_list.md
@@ -39,7 +39,7 @@ Pagination options | N | (see [Overview - Request Modifiers][])
             "display_name": "Phone Number",
             "inbound_notification_url": null,
             "outbound_notification_url": null,
-            "allow_communications": true,
+            "allow_messages": true,
             "priority": 0,
             "is_global": true
         },
@@ -49,7 +49,7 @@ Pagination options | N | (see [Overview - Request Modifiers][])
             "display_name": "Email Address",
             "inbound_notification_url": null,
             "outbound_notification_url": null,
-            "allow_communications": true,
+            "allow_messages": true,
             "priority": 1,
             "is_global": true
         },    
@@ -59,7 +59,7 @@ Pagination options | N | (see [Overview - Request Modifiers][])
             "display_name": "Chat ID",
             "inbound_notification_url": null,
             "outbound_notification_url": null,
-            "allow_communications": true,
+            "allow_messages": true,
             "priority": 2,
             "is_global": false
         }

--- a/channel_types/POST_create.md
+++ b/channel_types/POST_create.md
@@ -11,7 +11,7 @@ Field | Data Type | Required | Description
 display_name | string | Y | The display name of the channel type being created
 inbound_notification_url | string | N | URL to call whenever an inbound message is created using this Channel Type
 outbound_notification_url | string | N | URL to call whenever an outbound message is created using this Channel Type
-allow_communications | boolean | N | Whether this Channel Type allows communications. Defaults to true.
+allow_messages | boolean | N | Whether this Channel Type allows messages. Defaults to true.
 priority | integer | N | The default priority of this channel type (when sending group messages)
 
 ## Example
@@ -42,7 +42,7 @@ priority | integer | N | The default priority of this channel type (when sending
         "display_name": "Customer Chat ID",
         "inbound_notification_url": "https://www.myexample.com/notifiers/inbound-chat",
         "outbound_notification_url": "https://www.myexample.com/notifiers/outbound-chat",
-        "allow_communications": true,
+        "allow_messages": true,
         "priority": 0,
         "is_global": false
     }   

--- a/channel_types/PUT_update_id.md
+++ b/channel_types/PUT_update_id.md
@@ -11,7 +11,7 @@ Field | Data Type | Required | Description
 display_name | string | N | The display name of the channel type being created
 inbound_notification_url | string | N | URL to call whenever an inbound message is created using this Channel Type
 outbound_notification_url | string | N | URL to call whenever an outbound message is created using this Channel Type
-allow_communications | boolean | N | Whether this Channel Type allows communications. Defaults to true.
+allow_messages | boolean | N | Whether this Channel Type allows messages. Defaults to true.
 priority | integer | N | The default priority of this channel type (when sending group messages)
 
 ## Example
@@ -41,7 +41,7 @@ priority | integer | N | The default priority of this channel type (when sending
         "display_name": "Customer Chat ID",
         "inbound_notification_url": "https://www.myexample.com/notifiers/inbound-chat-notice",
         "outbound_notification_url": "https://www.myexample.com/notifiers/outbound-chat-notice",
-        "allow_communications": true,
+        "allow_messages": true,
         "priority": 0,
         "is_global": false
     }   

--- a/channel_types/README.md
+++ b/channel_types/README.md
@@ -8,5 +8,5 @@ type_class | string | The identifying class of the channel type.  Available opti
 display_name | string | 
 inbound_notification_url | string | The URL to call when an inbound message is received on a channel of this type
 outbound_notification_url | string | The URL to call when an outbound message is sent on a channel of this type
-allow_communications | boolean | Whether or not this channel types allows a service to communicate with contacts
+allow_messages | boolean | Whether or not this channel types allows a service to communicate with contacts
 is_global | boolean | Whether the channel type is scoped to a single account

--- a/contact_channels/GET_id.md
+++ b/contact_channels/GET_id.md
@@ -34,7 +34,7 @@ None
       "display_name": "Phone Number",
       "inbound_notification_url": null,
       "outbound_notification_url": null,
-      "allow_communications": true
+      "allow_messages": true
     }
 }
 ```

--- a/contact_channels/POST_create.md
+++ b/contact_channels/POST_create.md
@@ -53,7 +53,7 @@ is_default_for_type | boolean | N | If set to true, will make this channel the d
         "display_name": "Phone Number",
         "inbound_notification_url": null,
         "outbound_notification_url": null,
-        "allow_communications": true
+        "allow_messages": true
       }
     }
 }

--- a/contact_channels/PUT_update_id.md
+++ b/contact_channels/PUT_update_id.md
@@ -48,7 +48,7 @@ is_default_for_type | boolean | N | If set to true, will make this channel the d
         "display_name": "Phone Number",
         "inbound_notification_url": null,
         "outbound_notification_url": null,
-        "allow_communications": true
+        "allow_messages": true
       }
     }
 }

--- a/contacts/GET_id.md
+++ b/contacts/GET_id.md
@@ -46,7 +46,7 @@ None
               "display_name": "Phone Number",
               "inbound_notification_url": null,
               "outbound_notification_url": null,
-              "allow_communications": true
+              "allow_messages": true
             }
           },
           {
@@ -63,7 +63,7 @@ None
               "display_name": "Phone Number",
               "inbound_notification_url": null,
               "outbound_notification_url": null,
-              "allow_communications": true
+              "allow_messages": true
             }
           }
         ],

--- a/contacts/GET_list.md
+++ b/contacts/GET_list.md
@@ -66,7 +66,7 @@ is_starred | N | Filter by starred status (true = starred, false = not starred)
               "display_name": "Phone Number",
               "inbound_notification_url": null,
               "outbound_notification_url": null,
-              "allow_communications": true
+              "allow_messages": true
             }
           },
           {
@@ -83,7 +83,7 @@ is_starred | N | Filter by starred status (true = starred, false = not starred)
               "display_name": "Phone Number",
               "inbound_notification_url": null,
               "outbound_notification_url": null,
-              "allow_communications": true
+              "allow_messages": true
             }
           }
         ],

--- a/service_channels/GET_id.md
+++ b/service_channels/GET_id.md
@@ -33,7 +33,7 @@ None
         "display_name": "Phone Number",
         "inbound_notification_url": null,
         "outbound_notification_url": null,
-        "allow_communications": true
+        "allow_messages": true
       }
     }
 }

--- a/service_channels/POST_create.md
+++ b/service_channels/POST_create.md
@@ -52,7 +52,7 @@ is_default_for_type | boolean | N | If set to true, will make this channel the d
         "display_name": "Phone Number",
         "inbound_notification_url": null,
         "outbound_notification_url": null,
-        "allow_communications": true
+        "allow_messages": true
       }
     }
 }

--- a/service_channels/PUT_update_id.md
+++ b/service_channels/PUT_update_id.md
@@ -46,7 +46,7 @@ is_default_for_type | boolean | N | If set to true, will make this channel the d
         "display_name": "Phone Number",
         "inbound_notification_url": null,
         "outbound_notification_url": null,
-        "allow_communications": true
+        "allow_messages": true
       }
     }
 }

--- a/service_settings/POST_create.md
+++ b/service_settings/POST_create.md
@@ -71,7 +71,7 @@ settings_field_option_id | Y | Required when setting a value for a [Settings Fie
                   "display_name": "Phone Number",
                   "inbound_notification_url": null,
                   "outbound_notification_url": null,
-                  "allow_communications": true
+                  "allow_messages": true
               }
           }
         ],
@@ -82,7 +82,7 @@ settings_field_option_id | Y | Required when setting a value for a [Settings Fie
               "display_name": "Phone Number",
               "inbound_notification_url": null,
               "outbound_notification_url": null,
-              "allow_communications": true
+              "allow_messages": true
           }
         ],
         "service_address": {

--- a/services/GET_id.md
+++ b/services/GET_id.md
@@ -59,7 +59,7 @@ None
                   "display_name": "Phone Number",
                   "inbound_notification_url": null,
                   "outbound_notification_url": null,
-                  "allow_communications": true
+                  "allow_messages": true
               }
           }
         ],
@@ -70,7 +70,7 @@ None
               "display_name": "Phone Number",
               "inbound_notification_url": null,
               "outbound_notification_url": null,
-              "allow_communications": true
+              "allow_messages": true
           }
         ],
         "contact_labels": [],

--- a/services/GET_list.md
+++ b/services/GET_list.md
@@ -86,7 +86,7 @@ postal_code | N | Filter by Service postal_code
                   "display_name": "Phone Number",
                   "inbound_notification_url": null,
                   "outbound_notification_url": null,
-                  "allow_communications": true
+                  "allow_messages": true
               }
           }
         ],
@@ -97,7 +97,7 @@ postal_code | N | Filter by Service postal_code
               "display_name": "Phone Number",
               "inbound_notification_url": null,
               "outbound_notification_url": null,
-              "allow_communications": true
+              "allow_messages": true
           }
         ],
         "contact_labels": [],

--- a/services/POST_create.md
+++ b/services/POST_create.md
@@ -87,7 +87,7 @@ service_address | Y | [Service Address] object. All fields required
                   "display_name": "Phone Number",
                   "inbound_notification_url": null,
                   "outbound_notification_url": null,
-                  "allow_communications": true
+                  "allow_messages": true
               }
           }
         ],
@@ -98,7 +98,7 @@ service_address | Y | [Service Address] object. All fields required
               "display_name": "Phone Number",
               "inbound_notification_url": null,
               "outbound_notification_url": null,
-              "allow_communications": true
+              "allow_messages": true
           }
         ],
         "service_address": {

--- a/services/PUT_update_id.md
+++ b/services/PUT_update_id.md
@@ -77,7 +77,7 @@ service_address | [Service Address] object.
                   "display_name": "Phone Number",
                   "inbound_notification_url": null,
                   "outbound_notification_url": null,
-                  "allow_communications": true
+                  "allow_messages": true
               }
           }
         ],
@@ -90,7 +90,7 @@ service_address | [Service Address] object.
               "display_name": "Phone Number",
               "inbound_notification_url": null,
               "outbound_notification_url": null,
-              "allow_communications": true
+              "allow_messages": true
           }
         ],
         "service_address": {


### PR DESCRIPTION
I saw that You changed variable "allow_communications" for  contact channels, but I'm not found that information in rest-api docs.
Also I think we need change variable "allow_communications" for service channels too?
Notes: This commit contents renamed from allow_communications to allow_messages for service and contact channels
