### PR TITLE
fix Contact Custom Field Value Object, because now it is very similar…

### DIFF
--- a/custom_field_values/README.md
+++ b/custom_field_values/README.md
@@ -2,8 +2,8 @@
 
 Field | Data Type | Description
 --- | --- | ---
-value | string, boolean, or UNIX timestamp | Settings value. Data type is dependent on the settings field data type
-selected_settings_field_option_id | integer | ID of the selected settings field option ID, for settings fields with options
-settings_field | object | [Contact Field]
+value | string, boolean, or UNIX timestamp | Custom field value. Data type is dependent on the custom field data type
+selected_custom_field_option_id | integer | ID of the selected custom field option ID, for custom fields with options
+custom_field | object | [Contact Field]
 
 [Contact Field]: /contact_custom_fields/README.md


### PR DESCRIPTION
fix Contact Custom Field Value Object, because now it is incorrect (very similar to Service Settings Object)
For check issue you could doing any Contact request, for example:
`https://qa-api.zingle.me/v1/services/ fd178f4e-39ab-46dd-a917-3a0b2a28c230/contacts/5026885a-9b14-49d8-a611-5884d4be4e04`
